### PR TITLE
Adding configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,33 @@
+/*
+ * Create and export config variables
+ *
+ */
+
+// container for all the environments
+var environments = {};
+// Staging (default) env
+environments.staging = {
+  port: 3000,
+  envName: "staging"
+};
+
+// Production env
+environments.production = {
+  port: 5000,
+  envName: "production"
+};
+
+// Determine which environment was passed as a comman-line arg
+var currentEnvironment =
+  typeof process.env.NODE_ENV == "string"
+    ? process.env.NODE_ENV.toLowerCase()
+    : "";
+
+// Check that the current env is one of the envs above if not, default to staging
+var environmentToExport =
+  typeof environments[currentEnvironment] == "object"
+    ? environments[currentEnvironment]
+    : environments.staging;
+
+// export the module
+module.exports = environmentToExport;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 var http = require("http");
 var url = require("url");
 var StringDecoder = require("string_decoder").StringDecoder;
+var config = require("./config");
 
 // Configure the server to respond to all requests with a string
 var server = http.createServer(function(req, res) {
@@ -66,8 +67,14 @@ var server = http.createServer(function(req, res) {
 });
 
 // Start the server
-server.listen(3000, function() {
-  console.log("The server is up and running now");
+server.listen(config.port, function() {
+  console.log(
+    "The server is listening on " +
+      config.port +
+      " in " +
+      config.envName +
+      " mode."
+  );
 });
 
 // Define handlers

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var server = http.createServer(function(req, res) {
       // Convert the payload to a string
       var payloadString = JSON.stringify(payload);
       // Return the response
-      res.setHeader("Content-Type","application/json")
+      res.setHeader("Content-Type", "application/json");
       res.writeHead(statusCode);
       res.end(payloadString);
       // Log the request/response


### PR DESCRIPTION
Add config environments for staging and production and the logic to determine which is specified by NODE_ENV
```javascript
/*
 * Create and export config variables
 *
 */

// container for all the environments
var environments = {};
// Staging (default) env
environments.staging = {
  port: 3000,
  envName: "staging"
};

// Production env
environments.production = {
  port: 5000,
  envName: "production"
};

// Determine which environment was passed as a comman-line arg
var currentEnvironment =
  typeof process.env.NODE_ENV == "string"
    ? process.env.NODE_ENV.toLowerCase()
    : "";

// Check that the current env is one of the envs above if not, default to staging
var environmentToExport =
  typeof environments[currentEnvironment] == "object"
    ? environments[currentEnvironment]
    : environments.staging;

// export the module
module.exports = environmentToExport;

```